### PR TITLE
Add to custom-theme-load-path and user customizability

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ Add these lines to your 'init.el':
 (use-package jetbrains-darcula-theme
   :straight (:host github :repo "ianpan870102/jetbrains-darcula-emacs-theme")
   :custom
-  (add-to-list 'custom-theme-load-path "~/.emacs.d/straight/repos/jetbrains-darcula-emacs-theme/")
   (load-theme 'jetbrains-darcula t))
 ```
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,39 @@ Add these lines to your 'init.el':
   (load-theme 'jetbrains-darcula t))
 ```
 
+#### User-customization
+
+You need `after-load-theme-hook`, if you don't already have it, define one like this:
+
+```
+(defvar after-load-theme-hook nil
+  "Hook run after a color theme is loaded using `load-theme'.")
+
+(defun run-after-load-theme-hook (&rest _)
+  "Run `after-load-theme-hook'."
+  (run-hooks 'after-load-theme-hook))
+
+(advice-add #'load-theme :after #'run-after-load-theme-hook)
+```
+
+Then in your `use-package` declaration:
+
+```
+(use-package jetbrains-darcula-theme
+  :straight (:host github :repo "ianpan870102/jetbrains-darcula-emacs-theme")
+  :config
+  (defun customize-jetbrains-darcula ()
+    "Customize jetbrains darcula theme"
+    (if (member 'jetbrains-darcula custom-enabled-themes)
+        (jetbrains-darcula-with-color-variables
+         (custom-theme-set-faces
+          'jetbrains-darcula
+          `(default ((t (:foreground ,fg1 :background ,bg0))))
+          ))))
+  (add-hook 'after-load-theme-hook 'customize-jetbrains-darcula)
+  (load-theme 'jetbrains-darcula t))
+```
+
 #### Screenshots
 
 ![alt text](./darcula1.png)

--- a/jetbrains-darcula-theme.el
+++ b/jetbrains-darcula-theme.el
@@ -24,50 +24,77 @@
 ;;; Code:
 
 (deftheme jetbrains-darcula)
-(let ((class '((class color) (min-colors 89)))
-      (fg0               "#8997a6")
-      (fg1               "#a9b7c6") ; default fg
-      (fg2               "#cccccc")
-      (fg3               "#e8e8e8")
-      (fg4               "#fafafa")
-      (bg00              "#000000")
-      (bg0               "#111111")
-      (bg1               "#2b2b2b") ; default bg
-      (bg2               "#303030")
-      (bg3               "#313335") ; hl-line
-      (bg4               "#383c3f")
-      (bg-hl             "#214283")
-      (jb-r              "#8c0909")
-      (jb-g              "#365546")
-      (jb-b              "#214283")
-      (key2              "#c57825")
-      (key3              "#d0d0ff")
-      (accent            "#ffffff")
-      (mode-line-bg      "#3c3f41")
-      (mode-line-bg-dark "#2c2f31")
-      (line-num          "#606366")
-      (builtin           "#c57825")
-      (keyword           "#c57825")
-      (const             "#9676ac")
-      (comment           "#8e9292")
-      (doc               "#5e8759")
-      (func              "#ffc66d")
-      (str               "#5e8759")
-      (type              "#c57825")
-      (var               "#9676ac")
-      (warning           "#990000")
 
-      ;; standardized palette
-      (jb-yellow      "#ffc66d")
-      (jb-bluegreen   "#318495")
-      (jb-magenta     "#9676ac")
-      (jb-lightblue   "#d0d0ff")
-      (jb-orange      "#c57825")
-      (jb-red         "#8c0909")
-      (jb-blue        "#7ca8c6")
-      (jb-lightgreen  "#aeae80")
-      (jb-green       "#5e8759")
-      )
+;;;###autoload
+(defcustom jetbrains-darcula-override-colors-alist '()
+  "Place to override default theme colors.
+
+You can override a subset of the theme's default colors by
+defining them in this alist."
+  :group 'jetbrains-darcula-theme
+  :type '(alist
+          :key-type (string :tag "Name")
+          :value-type (string :tag " Hex")))
+
+;;; Color Palette
+
+(defvar jetbrains-darcula-default-colors-alist
+  '(("fg0"               . "#8997a6")
+    ("fg1"               . "#a9b7c6") ; default fg
+    ("fg2"               . "#cccccc")
+    ("fg3"               . "#e8e8e8")
+    ("fg4"               . "#fafafa")
+    ("bg00"              . "#000000")
+    ("bg0"               . "#111111")
+    ("bg1"               . "#2b2b2b") ; default bg
+    ("bg2"               . "#303030")
+    ("bg3"               . "#313335") ; hl-line
+    ("bg4"               . "#383c3f")
+    ("bg-hl"             . "#214283")
+    ("jb-r"              . "#8c0909")
+    ("jb-g"              . "#365546")
+    ("jb-b"              . "#214283")
+    ("key2"              . "#c57825")
+    ("key3"              . "#d0d0ff")
+    ("accent"            . "#ffffff")
+    ("mode-line-bg"      . "#3c3f41")
+    ("mode-line-bg-dark" . "#2c2f31")
+    ("line-num"          . "#606366")
+    ("builtin"           . "#c57825")
+    ("keyword"           . "#c57825")
+    ("const"             . "#9676ac")
+    ("comment"           . "#8e9292")
+    ("doc"               . "#5e8759")
+    ("func"              . "#ffc66d")
+    ("str"               . "#5e8759")
+    ("type"              . "#c57825")
+    ("var"               . "#9676ac")
+    ("warning"           . "#990000")
+
+    ;; standardized palette
+    ("jb-yellow"     . "#ffc66d")
+    ("jb-bluegreen"  . "#318495")
+    ("jb-magenta"    . "#9676ac")
+    ("jb-lightblue"  . "#d0d0ff")
+    ("jb-orange"     . "#c57825")
+    ("jb-red"        . "#8c0909")
+    ("jb-blue"       . "#7ca8c6")
+    ("jb-lightgreen" . "#aeae80")
+    ("jb-green"      . "#5e8759")
+    ))
+
+(defmacro jetbrains-darcula-with-color-variables (&rest body)
+  "`let' bind all colors around BODY.
+Also bind `class' to ((class color) (min-colors 89))."
+  (declare (indent 0))
+  `(let ((class '((class color) (min-colors 89)))
+         ,@(mapcar (lambda (cons)
+                     (list (intern (car cons)) (cdr cons)))
+                   (append jetbrains-darcula-default-colors-alist
+                           jetbrains-darcula-override-colors-alist)))
+     ,@body))
+
+(jetbrains-darcula-with-color-variables
   (custom-theme-set-faces
    'jetbrains-darcula
    `(default                                  ((,class (:background ,bg1 :foreground ,fg1))))

--- a/jetbrains-darcula-theme.el
+++ b/jetbrains-darcula-theme.el
@@ -449,6 +449,13 @@
    `(highlight-symbol-face                    ((t (:background "#343a40"))))
    ))
 
+;;; Footer
+
+;;;###autoload
+(when (and (boundp 'custom-theme-load-path) load-file-name)
+  (add-to-list 'custom-theme-load-path
+               (file-name-as-directory (file-name-directory load-file-name))))
+
 (provide-theme 'jetbrains-darcula)
 
 ;;; jetbrains-darcula-theme.el ends here


### PR DESCRIPTION
* Automatically add to custom-theme-load-path.

* Put colors into `jetbrains-darcula-default-colors-alist`, allow override via `jetbrains-darcula-override-colors-alist`, and access via `jetbrains-darcula-with-color-variables` macro.

* Provide example in README.


Fixes #1 
